### PR TITLE
Fix for Issue #1

### DIFF
--- a/new.cu
+++ b/new.cu
@@ -66,7 +66,7 @@ void pre_sha256() {
     cudaMemcpyToSymbol(dev_k, host_k, sizeof(host_k), 0, cudaMemcpyHostToDevice);
 }
 
-long long timems() {
+unsigned long long timems() {
     struct timeval end;
     gettimeofday(&end, NULL);
     return end.tv_sec * 1000LL + end.tv_usec / 1000;
@@ -136,7 +136,7 @@ int main() {
 
     unsigned long **processedPtrs = (unsigned long **) malloc(sizeof(unsigned long *) * GPUS);
     pthread_t *tids = (pthread_t *) malloc(sizeof(pthread_t) * GPUS);
-    long long start = timems();
+    unsigned long long start = timems();
     for (int i = 0; i < GPUS; i++) {
         HandlerInput *hi = (HandlerInput *) malloc(sizeof(HandlerInput));
         hi->device = i;
@@ -151,7 +151,7 @@ int main() {
         for (int i = 0; i < GPUS; i++) {
             totalProcessed += *(processedPtrs[i]);
         }
-        long long elapsed = timems() - start;
+        unsigned long long elapsed = timems() - start;
         printf("Hashes (%'lu) Seconds (%'f) Hashes/sec (%'lu)\r", totalProcessed, ((float) elapsed) / 1000.0, (unsigned long) ((double) totalProcessed / (double) elapsed) * 1000);
         if (solution) {
             break;
@@ -160,8 +160,8 @@ int main() {
     printf("\n");
 
     pthread_mutex_lock(&solutionLock);
-    long long end = timems();
-    long long elapsed = end - start;
+    unsigned long long end = timems();
+    unsigned long long elapsed = end - start;
 
     for (int i = 0; i < GPUS; i++) {
         pthread_join(tids[i], NULL);


### PR DESCRIPTION
Get Time in microseconds from timems function. Will ensure better accuracy of rngSeed.

The / 1000 was sometimes negating the added benefit of end.tv_usec. On linux system this was sometimes causing issues when the end.tv_usec value was in the 1e3 or 1e4 range.

You would have to catch it at the precise time for you to reproduce the issue. Multiple starts are required usually. 